### PR TITLE
Llm error handling

### DIFF
--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -58,11 +58,14 @@ class PromptCallableBase:
         wait=wait_exponential_jitter(max=60),
         retry=retry_if_exception_type(RETRYABLE_ERRORS),
     )
-    def __call__(self, *args, **kwargs) -> LLMResponse:
-        try:
-            result = self.invoke_llm(
+    def call_llm(self, *args, **kwargs) -> LLMResponse:
+        return self.invoke_llm(
                 *self.init_args, *args, **self.init_kwargs, **kwargs
             )
+
+    def __call__(self, *args, **kwargs) -> LLMResponse:
+        try:
+            result = self.call_llm(*args, **kwargs)
         except Exception as e:
             raise PromptCallableException(
                 "The callable `fn` passed to `Guard(fn, ...)` failed"
@@ -326,11 +329,14 @@ class AsyncPromptCallableBase:
         wait=wait_exponential_jitter(max=60),
         retry=retry_if_exception_type(RETRYABLE_ERRORS),
     )
-    def __call__(self, *args, **kwargs) -> LLMResponse:
-        try:
-            result = self.invoke_llm(
+    async def call_llm(self, *args, **kwargs) -> LLMResponse:
+        return await self.invoke_llm(
                 *self.init_args, *args, **self.init_kwargs, **kwargs
             )
+
+    async def __call__(self, *args, **kwargs) -> LLMResponse:
+        try:
+            result = await self.call_llm(*args, **kwargs)
         except Exception as e:
             raise PromptCallableException(
                 "The callable `fn` passed to `Guard(fn, ...)` failed"
@@ -498,8 +504,9 @@ class AsyncArbitraryCallable(AsyncPromptCallableBase):
         )
         ```
         """
+        output = await self.llm_api(*args, **kwargs)
         return LLMResponse(
-            output=self.llm_api(*args, **kwargs),
+            output=output,
         )
 
 

--- a/guardrails/llm_providers.py
+++ b/guardrails/llm_providers.py
@@ -59,9 +59,7 @@ class PromptCallableBase:
         retry=retry_if_exception_type(RETRYABLE_ERRORS),
     )
     def call_llm(self, *args, **kwargs) -> LLMResponse:
-        return self.invoke_llm(
-                *self.init_args, *args, **self.init_kwargs, **kwargs
-            )
+        return self.invoke_llm(*self.init_args, *args, **self.init_kwargs, **kwargs)
 
     def __call__(self, *args, **kwargs) -> LLMResponse:
         try:
@@ -331,8 +329,8 @@ class AsyncPromptCallableBase:
     )
     async def call_llm(self, *args, **kwargs) -> LLMResponse:
         return await self.invoke_llm(
-                *self.init_args, *args, **self.init_kwargs, **kwargs
-            )
+            *self.init_args, *args, **self.init_kwargs, **kwargs
+        )
 
     async def __call__(self, *args, **kwargs) -> LLMResponse:
         try:

--- a/guardrails/run.py
+++ b/guardrails/run.py
@@ -595,32 +595,32 @@ class AsyncRunner(Runner):
             llm_response = None
             try:
                 if msg_history:
-                    llm_response = await api.invoke_llm(
+                    llm_response = await api(
                         msg_history=msg_history,
                         base_model=self.base_model,
                     )
                 else:
                     if prompt and instructions:
-                        llm_response = await api.invoke_llm(
+                        llm_response = await api(
                             prompt.source,
                             instructions=instructions.source,
                             base_model=self.base_model,
                         )
                     elif prompt:
-                        llm_response = await api.invoke_llm(
+                        llm_response = await api(
                             prompt.source, base_model=self.base_model
                         )
             except Exception:
                 # If the API call fails, try calling again without the base model.
                 if msg_history:
-                    llm_response = await api.invoke_llm(msg_history=msg_history)
+                    llm_response = await api(msg_history=msg_history)
                 else:
                     if prompt and instructions:
-                        llm_response = await api.invoke_llm(
+                        llm_response = await api(
                             prompt.source, instructions=instructions.source
                         )
                     elif prompt:
-                        llm_response = await api.invoke_llm(prompt.source)
+                        llm_response = await api(prompt.source)
 
             if llm_response is None:
                 llm_response = LLMResponse(

--- a/tests/unit_tests/mocks/__init__.py
+++ b/tests/unit_tests/mocks/__init__.py
@@ -1,8 +1,8 @@
 from .mock_async_validator_service import MockAsyncValidatorService
+from .mock_custom_llm import MockAsyncCustomLlm, MockCustomLlm
 from .mock_loop import MockLoop
 from .mock_sequential_validator_service import MockSequentialValidatorService
 from .mock_validator import MockValidator
-from .mock_custom_llm import MockCustomLlm, MockAsyncCustomLlm
 
 __all__ = [
     "MockAsyncValidatorService",

--- a/tests/unit_tests/mocks/__init__.py
+++ b/tests/unit_tests/mocks/__init__.py
@@ -2,10 +2,13 @@ from .mock_async_validator_service import MockAsyncValidatorService
 from .mock_loop import MockLoop
 from .mock_sequential_validator_service import MockSequentialValidatorService
 from .mock_validator import MockValidator
+from .mock_custom_llm import MockCustomLlm, MockAsyncCustomLlm
 
 __all__ = [
     "MockAsyncValidatorService",
     "MockSequentialValidatorService",
     "MockLoop",
     "MockValidator",
+    "MockCustomLlm",
+    "MockAsyncCustomLlm",
 ]

--- a/tests/unit_tests/mocks/mock_custom_llm.py
+++ b/tests/unit_tests/mocks/mock_custom_llm.py
@@ -1,36 +1,37 @@
 import openai
 
-class MockCustomLlm():
-    def __init__(self, times_called = 0, response = "Hello world!"):
+
+class MockCustomLlm:
+    def __init__(self, times_called=0, response="Hello world!"):
         self.times_called = times_called
         self.response = response
-    
-    def fail_retryable (self, prompt: str, *args, **kwargs) -> str:
+
+    def fail_retryable(self, prompt: str, *args, **kwargs) -> str:
         if self.times_called == 0:
             self.times_called = self.times_called + 1
             raise openai.error.ServiceUnavailableError("ServiceUnavailableError")
         return self.response
 
-    def fail_non_retryable (self, prompt: str, *args, **kwargs) -> str:
+    def fail_non_retryable(self, prompt: str, *args, **kwargs) -> str:
         raise Exception("Non-Retryable Error!")
 
-    def succeed (self, prompt: str, *args, **kwargs) -> str:
+    def succeed(self, prompt: str, *args, **kwargs) -> str:
         return self.response
 
 
-class MockAsyncCustomLlm():
-    def __init__(self, times_called = 0, response = "Hello world!"):
+class MockAsyncCustomLlm:
+    def __init__(self, times_called=0, response="Hello world!"):
         self.times_called = times_called
         self.response = response
-    
-    async def fail_retryable (self, prompt: str, *args, **kwargs) -> str:
+
+    async def fail_retryable(self, prompt: str, *args, **kwargs) -> str:
         if self.times_called == 0:
             self.times_called = self.times_called + 1
             raise openai.error.ServiceUnavailableError("ServiceUnavailableError")
         return self.response
 
-    async def fail_non_retryable (self, prompt: str, *args, **kwargs) -> str:
+    async def fail_non_retryable(self, prompt: str, *args, **kwargs) -> str:
         raise Exception("Non-Retryable Error!")
 
-    async def succeed (self, prompt: str, *args, **kwargs) -> str:
+    async def succeed(self, prompt: str, *args, **kwargs) -> str:
         return self.response

--- a/tests/unit_tests/mocks/mock_custom_llm.py
+++ b/tests/unit_tests/mocks/mock_custom_llm.py
@@ -1,0 +1,36 @@
+import openai
+
+class MockCustomLlm():
+    def __init__(self, times_called = 0, response = "Hello world!"):
+        self.times_called = times_called
+        self.response = response
+    
+    def fail_retryable (self, prompt: str, *args, **kwargs) -> str:
+        if self.times_called == 0:
+            self.times_called = self.times_called + 1
+            raise openai.error.ServiceUnavailableError("ServiceUnavailableError")
+        return self.response
+
+    def fail_non_retryable (self, prompt: str, *args, **kwargs) -> str:
+        raise Exception("Non-Retryable Error!")
+
+    def succeed (self, prompt: str, *args, **kwargs) -> str:
+        return self.response
+
+
+class MockAsyncCustomLlm():
+    def __init__(self, times_called = 0, response = "Hello world!"):
+        self.times_called = times_called
+        self.response = response
+    
+    async def fail_retryable (self, prompt: str, *args, **kwargs) -> str:
+        if self.times_called == 0:
+            self.times_called = self.times_called + 1
+            raise openai.error.ServiceUnavailableError("ServiceUnavailableError")
+        return self.response
+
+    async def fail_non_retryable (self, prompt: str, *args, **kwargs) -> str:
+        raise Exception("Non-Retryable Error!")
+
+    async def succeed (self, prompt: str, *args, **kwargs) -> str:
+        return self.response

--- a/tests/unit_tests/test_llm_providers.py
+++ b/tests/unit_tests/test_llm_providers.py
@@ -1,62 +1,72 @@
 import pytest
-from guardrails.llm_providers import ArbitraryCallable, AsyncArbitraryCallable, LLMResponse, PromptCallableException
-from .mocks import MockCustomLlm, MockAsyncCustomLlm
+
+from guardrails.llm_providers import (
+    ArbitraryCallable,
+    AsyncArbitraryCallable,
+    LLMResponse,
+    PromptCallableException,
+)
+
+from .mocks import MockAsyncCustomLlm, MockCustomLlm
 
 
 def test_arbitrary_callable_retries_on_retryable_errors(mocker):
     llm = MockCustomLlm()
-    fail_retryable_spy = mocker.spy(llm, 'fail_retryable')
-    
+    fail_retryable_spy = mocker.spy(llm, "fail_retryable")
+
     arbitrary_callable = ArbitraryCallable(llm.fail_retryable, prompt="Hello")
     response = arbitrary_callable()
 
     assert fail_retryable_spy.call_count == 2
     assert isinstance(response, LLMResponse) is True
     assert response.output == "Hello world!"
-    assert response.prompt_token_count == None
-    assert response.response_token_count == None
+    assert response.prompt_token_count is None
+    assert response.response_token_count is None
 
 
 def test_arbitrary_callable_does_not_retry_on_non_retryable_errors(mocker):
     with pytest.raises(Exception) as e:
         llm = MockCustomLlm()
-        fail_non_retryable_spy = mocker.spy(llm, 'fail_non_retryable')
-        
+        fail_non_retryable_spy = mocker.spy(llm, "fail_non_retryable")
+
         arbitrary_callable = ArbitraryCallable(llm.fail_retryable, prompt="Hello")
         arbitrary_callable()
 
         assert fail_non_retryable_spy.call_count == 1
         assert isinstance(e, PromptCallableException) is True
-        assert str(e) == "The callable `fn` passed to `Guard(fn, ...)` failed with the following error: `Non-Retryable Error!`. Make sure that `fn` can be called as a function that takes in a single prompt string and returns a string."
+        assert (
+            str(e)
+            == "The callable `fn` passed to `Guard(fn, ...)` failed with the following error: `Non-Retryable Error!`. Make sure that `fn` can be called as a function that takes in a single prompt string and returns a string."  # noqa
+        )
 
 
 def test_arbitrary_callable_does_not_retry_on_success(mocker):
     llm = MockCustomLlm()
-    succeed_spy = mocker.spy(llm, 'succeed')
-    
+    succeed_spy = mocker.spy(llm, "succeed")
+
     arbitrary_callable = ArbitraryCallable(llm.succeed, prompt="Hello")
     response = arbitrary_callable()
 
     assert succeed_spy.call_count == 1
     assert isinstance(response, LLMResponse) is True
     assert response.output == "Hello world!"
-    assert response.prompt_token_count == None
-    assert response.response_token_count == None
+    assert response.prompt_token_count is None
+    assert response.response_token_count is None
 
 
 @pytest.mark.asyncio
 async def test_async_arbitrary_callable_retries_on_retryable_errors(mocker):
     llm = MockAsyncCustomLlm()
-    fail_retryable_spy = mocker.spy(llm, 'fail_retryable')
-    
+    fail_retryable_spy = mocker.spy(llm, "fail_retryable")
+
     arbitrary_callable = AsyncArbitraryCallable(llm.fail_retryable, prompt="Hello")
     response = await arbitrary_callable()
 
     assert fail_retryable_spy.call_count == 2
     assert isinstance(response, LLMResponse) is True
     assert response.output == "Hello world!"
-    assert response.prompt_token_count == None
-    assert response.response_token_count == None
+    assert response.prompt_token_count is None
+    assert response.response_token_count is None
 
 
 # Passing
@@ -64,27 +74,29 @@ async def test_async_arbitrary_callable_retries_on_retryable_errors(mocker):
 async def test_async_arbitrary_callable_does_not_retry_on_non_retryable_errors(mocker):
     with pytest.raises(Exception) as e:
         llm = MockAsyncCustomLlm()
-        fail_non_retryable_spy = mocker.spy(llm, 'fail_non_retryable')
-        
+        fail_non_retryable_spy = mocker.spy(llm, "fail_non_retryable")
+
         arbitrary_callable = AsyncArbitraryCallable(llm.fail_retryable, prompt="Hello")
         await arbitrary_callable()
 
         assert fail_non_retryable_spy.call_count == 1
         assert isinstance(e, PromptCallableException) is True
-        assert str(e) == "The callable `fn` passed to `Guard(fn, ...)` failed with the following error: `Non-Retryable Error!`. Make sure that `fn` can be called as a function that takes in a single prompt string and returns a string."
+        assert (
+            str(e)
+            == "The callable `fn` passed to `Guard(fn, ...)` failed with the following error: `Non-Retryable Error!`. Make sure that `fn` can be called as a function that takes in a single prompt string and returns a string."  # noqa
+        )
 
 
 @pytest.mark.asyncio
 async def test_async_arbitrary_callable_does_not_retry_on_success(mocker):
     llm = MockAsyncCustomLlm()
-    succeed_spy = mocker.spy(llm, 'succeed')
-    
+    succeed_spy = mocker.spy(llm, "succeed")
+
     arbitrary_callable = AsyncArbitraryCallable(llm.succeed, prompt="Hello")
     response = await arbitrary_callable()
 
     assert succeed_spy.call_count == 1
     assert isinstance(response, LLMResponse) is True
     assert response.output == "Hello world!"
-    assert response.prompt_token_count == None
-    assert response.response_token_count == None
-
+    assert response.prompt_token_count is None
+    assert response.response_token_count is None

--- a/tests/unit_tests/test_llm_providers.py
+++ b/tests/unit_tests/test_llm_providers.py
@@ -1,0 +1,90 @@
+import pytest
+from guardrails.llm_providers import ArbitraryCallable, AsyncArbitraryCallable, LLMResponse, PromptCallableException
+from .mocks import MockCustomLlm, MockAsyncCustomLlm
+
+
+def test_arbitrary_callable_retries_on_retryable_errors(mocker):
+    llm = MockCustomLlm()
+    fail_retryable_spy = mocker.spy(llm, 'fail_retryable')
+    
+    arbitrary_callable = ArbitraryCallable(llm.fail_retryable, prompt="Hello")
+    response = arbitrary_callable()
+
+    assert fail_retryable_spy.call_count == 2
+    assert isinstance(response, LLMResponse) is True
+    assert response.output == "Hello world!"
+    assert response.prompt_token_count == None
+    assert response.response_token_count == None
+
+
+def test_arbitrary_callable_does_not_retry_on_non_retryable_errors(mocker):
+    with pytest.raises(Exception) as e:
+        llm = MockCustomLlm()
+        fail_non_retryable_spy = mocker.spy(llm, 'fail_non_retryable')
+        
+        arbitrary_callable = ArbitraryCallable(llm.fail_retryable, prompt="Hello")
+        arbitrary_callable()
+
+        assert fail_non_retryable_spy.call_count == 1
+        assert isinstance(e, PromptCallableException) is True
+        assert str(e) == "The callable `fn` passed to `Guard(fn, ...)` failed with the following error: `Non-Retryable Error!`. Make sure that `fn` can be called as a function that takes in a single prompt string and returns a string."
+
+
+def test_arbitrary_callable_does_not_retry_on_success(mocker):
+    llm = MockCustomLlm()
+    succeed_spy = mocker.spy(llm, 'succeed')
+    
+    arbitrary_callable = ArbitraryCallable(llm.succeed, prompt="Hello")
+    response = arbitrary_callable()
+
+    assert succeed_spy.call_count == 1
+    assert isinstance(response, LLMResponse) is True
+    assert response.output == "Hello world!"
+    assert response.prompt_token_count == None
+    assert response.response_token_count == None
+
+
+@pytest.mark.asyncio
+async def test_async_arbitrary_callable_retries_on_retryable_errors(mocker):
+    llm = MockAsyncCustomLlm()
+    fail_retryable_spy = mocker.spy(llm, 'fail_retryable')
+    
+    arbitrary_callable = AsyncArbitraryCallable(llm.fail_retryable, prompt="Hello")
+    response = await arbitrary_callable()
+
+    assert fail_retryable_spy.call_count == 2
+    assert isinstance(response, LLMResponse) is True
+    assert response.output == "Hello world!"
+    assert response.prompt_token_count == None
+    assert response.response_token_count == None
+
+
+# Passing
+@pytest.mark.asyncio
+async def test_async_arbitrary_callable_does_not_retry_on_non_retryable_errors(mocker):
+    with pytest.raises(Exception) as e:
+        llm = MockAsyncCustomLlm()
+        fail_non_retryable_spy = mocker.spy(llm, 'fail_non_retryable')
+        
+        arbitrary_callable = AsyncArbitraryCallable(llm.fail_retryable, prompt="Hello")
+        await arbitrary_callable()
+
+        assert fail_non_retryable_spy.call_count == 1
+        assert isinstance(e, PromptCallableException) is True
+        assert str(e) == "The callable `fn` passed to `Guard(fn, ...)` failed with the following error: `Non-Retryable Error!`. Make sure that `fn` can be called as a function that takes in a single prompt string and returns a string."
+
+
+@pytest.mark.asyncio
+async def test_async_arbitrary_callable_does_not_retry_on_success(mocker):
+    llm = MockAsyncCustomLlm()
+    succeed_spy = mocker.spy(llm, 'succeed')
+    
+    arbitrary_callable = AsyncArbitraryCallable(llm.succeed, prompt="Hello")
+    response = await arbitrary_callable()
+
+    assert succeed_spy.call_count == 1
+    assert isinstance(response, LLMResponse) is True
+    assert response.output == "Hello world!"
+    assert response.prompt_token_count == None
+    assert response.response_token_count == None
+


### PR DESCRIPTION
The main focus of this PR is to re-work our exception handling when calling llms.  Previously we were catching any exception and raising a `PromptCallableException`.  Since this was not in our list of RETRYABLE_ERRORS for tenacity, automatic retries with backoff were not happening.

This moves the llm call to its own isolated function wrapped in tenacity's retry and keeps the same exception handling on the method that calls this new function so that if a non-retryable error occurs or we hit our retry limit, the same `PromptCallableException` will be thrown.

This PR also fixes a few minor issues in https://github.com/guardrails-ai/guardrails/pull/4 for async flows and adds tests that cover the exception handling mentioned above, the `ArbitraryCallable` classes for custom llms, as well as the base logic in the `PromptCallableBase` classes.